### PR TITLE
implements partial match functionality

### DIFF
--- a/lib/texticle.rb
+++ b/lib/texticle.rb
@@ -61,9 +61,20 @@ module Texticle
         column = connection.quote_column_name(column_or_table)
         search_term = connection.quote normalize(Helper.normalize(search_term))
         @similarities << "ts_rank(to_tsvector(#{language}, #{table_name}.#{column}::text), to_tsquery(#{language}, #{search_term}::text))"
-        @conditions << "to_tsvector(#{language}, #{table_name}.#{column}::text) @@ to_tsquery(#{language}, #{search_term}::text)"
+        condition = "to_tsvector(#{language}, #{table_name}.#{column}::text) @@ to_tsquery(#{language}, #{search_term}::text)"
+        partial_match_condition = " OR #{table_name}.#{column} #{partial_match_case_sensitive ? 'LIKE' : 'ILIKE'} #{search_term}"
+        condition = condition + partial_match_condition if partial_match && column !~ /id/
+        @conditions << condition
       end
     end
+  end
+
+  def partial_match
+    false
+  end
+
+  def partial_match_case_sensitive
+    false
   end
 
   def normalize(query)

--- a/spec/texticle_spec.rb
+++ b/spec/texticle_spec.rb
@@ -228,4 +228,44 @@ class TexticleTest < Test::Unit::TestCase
       assert_not_empty Game.search_by_title("harry")
     end
   end
+
+  context "when setting partial match" do
+    setup do
+      Game.create :system => "PS3", :title => "Harry Potter & the Deathly Hallows"
+      assert_empty Game.search_by_title("%rry%")
+      def Game.partial_match
+        true
+      end
+    end
+
+    teardown do
+      def Game.partial_match
+        false
+      end
+      Game.delete_all
+    end
+
+    should "search with word partial match" do
+      assert_not_empty Game.search_by_title("%rry%")
+    end
+
+    context "and setting patial match case sensitive" do
+      setup do
+        def Game.partial_match_case_sensitive
+          true
+        end
+      end
+
+      teardown do
+        def Game.partial_match_case_sensitive
+          true
+        end
+      end
+
+      should "search with case sensitive" do
+        assert_empty Game.search_by_title("%rry p%")
+        assert_not_empty Game.search_by_title("%rry P%")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Repost: https://github.com/tenderlove/texticle/pull/74#issuecomment-5479868

It's disabled by default to avoid conflict. Enable by defining partial_match to return true. And I've added tests for it.

Usage: Game.search('%rry%') => Can search for a game named "Harry"

I think it's fine to enable it by default as it require passing '%' to make it work. But need to update other two test cases so avoided :wink:
