### PR TITLE
Clean Up Tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ task :console do
 end
 
 task :test do
-  # require 'texticle_spec'
+  require 'texticle_spec'
   require 'texticle/searchable_spec'
   require 'texticle/full_text_indexer_spec'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -72,9 +72,9 @@ task :console do
 end
 
 task :test do
-  require 'texticle_spec'
+  # require 'texticle_spec'
   require 'texticle/searchable_spec'
-  require 'texticle/full_text_indexer_spec'
+  # require 'texticle/full_text_indexer_spec'
 end
 
 namespace :db do

--- a/Rakefile
+++ b/Rakefile
@@ -74,7 +74,7 @@ end
 task :test do
   # require 'texticle_spec'
   require 'texticle/searchable_spec'
-  # require 'texticle/full_text_indexer_spec'
+  require 'texticle/full_text_indexer_spec'
 end
 
 namespace :db do

--- a/spec/fixtures/character.rb
+++ b/spec/fixtures/character.rb
@@ -1,9 +1,0 @@
-require 'active_record'
-
-class Character < ActiveRecord::Base
-  # string :name
-  # string :description
-  # integer :web_comic_id
-
-  belongs_to :web_comic
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,31 @@ require 'yaml'
 require 'texticle'
 require 'shoulda'
 require 'pry'
+require 'active_record'
 
 config = YAML.load_file File.expand_path(File.dirname(__FILE__) + '/config.yml')
 ActiveRecord::Base.establish_connection config.merge(:adapter => :postgresql)
+
+class WebComic < ActiveRecord::Base
+  # string :name
+  # string :author
+  # integer :id
+
+  has_many :characters
+end
+
+class Character < ActiveRecord::Base
+  # string :name
+  # string :description
+  # integer :web_comic_id
+
+  belongs_to :web_comic
+end
+
+class Game < ActiveRecord::Base
+  # string :system
+  # string :title
+  # text :description
+end
+
+class GameFail < Game; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'texticle'
 require 'shoulda'
 require 'pry'
 require 'active_record'
+require 'texticle'
+require 'texticle/searchable'
 
 config = YAML.load_file File.expand_path(File.dirname(__FILE__) + '/config.yml')
 ActiveRecord::Base.establish_connection config.merge(:adapter => :postgresql)
@@ -16,6 +18,19 @@ class WebComic < ActiveRecord::Base
 
   has_many :characters
 end
+
+class WebComicWithSearchable < WebComic
+  extend Searchable
+end
+
+class WebComicWithSearchableName < WebComic
+  extend Searchable(:name)
+end
+
+class WebComicWithSearchableNameAndAuthor < WebComic
+  extend Searchable(:name, :author)
+end
+
 
 class Character < ActiveRecord::Base
   # string :name

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,19 @@ require 'texticle/searchable'
 config = YAML.load_file File.expand_path(File.dirname(__FILE__) + '/config.yml')
 ActiveRecord::Base.establish_connection config.merge(:adapter => :postgresql)
 
+class ARStandIn < ActiveRecord::Base;
+  self.abstract_class = true
+  extend Texticle
+end
+
+class NotThere < ARStandIn; end
+
+class TexticleWebComic < ARStandIn;
+  has_many :characters, :foreign_key => :web_comic_id
+  self.table_name = :web_comics
+end
+
+
 class WebComic < ActiveRecord::Base
   # string :name
   # string :author
@@ -40,10 +53,26 @@ class Character < ActiveRecord::Base
   belongs_to :web_comic
 end
 
+
 class Game < ActiveRecord::Base
   # string :system
   # string :title
   # text :description
 end
 
+class GameExtendedWithTexticle < Game
+  extend Texticle
+end
+
+class GameExtendedWithTexticleAndCustomLanguage < GameExtendedWithTexticle
+  def searchable_language
+    'spanish'
+  end
+end
+
+
 class GameFail < Game; end
+
+class GameFailExtendedWithTexticle < GameFail
+  extend Texticle
+end

--- a/spec/texticle/full_text_indexer_spec.rb
+++ b/spec/texticle/full_text_indexer_spec.rb
@@ -56,7 +56,6 @@ class FullTextIndexerTest < Test::Unit::TestCase
 
   context "when we've listed one specific field in a Searchable call" do
     setup do
-      WebComic.extend Searchable(:name)
       @indexer = Texticle::FullTextIndexer.new
       @output = StringIO.new
       @indexer.instance_variable_set(:@output_stream, @output)
@@ -64,7 +63,7 @@ class FullTextIndexerTest < Test::Unit::TestCase
 
     should "generate the right sql" do
       expected_sql = <<-MIGRATION
-class WebComicFullTextSearch < ActiveRecord::Migration
+class WebComicWithSearchableNameFullTextSearch < ActiveRecord::Migration
   def self.up
     execute(<<-SQL.strip)
       DROP index IF EXISTS web_comics_name_fts_idx;
@@ -82,7 +81,7 @@ class WebComicFullTextSearch < ActiveRecord::Migration
 end
 MIGRATION
 
-      @indexer.generate_migration('WebComic')
+      @indexer.generate_migration('WebComicWithSearchableName')
 
       assert_equal(expected_sql, @output.string)
     end
@@ -90,7 +89,6 @@ MIGRATION
 
   context "when we've listed two specific fields in a Searchable call" do
     setup do
-      WebComic.extend Searchable(:name, :author)
       @indexer = Texticle::FullTextIndexer.new
       @output = StringIO.new
       @indexer.instance_variable_set(:@output_stream, @output)
@@ -98,7 +96,7 @@ MIGRATION
 
     should "generate the right sql" do
       expected_sql = <<-MIGRATION
-class WebComicFullTextSearch < ActiveRecord::Migration
+class WebComicWithSearchableNameAndAuthorFullTextSearch < ActiveRecord::Migration
   def self.up
     execute(<<-SQL.strip)
       DROP index IF EXISTS web_comics_name_fts_idx;
@@ -121,7 +119,7 @@ class WebComicFullTextSearch < ActiveRecord::Migration
 end
 MIGRATION
 
-      @indexer.generate_migration('WebComic')
+      @indexer.generate_migration('WebComicWithSearchableNameAndAuthor')
 
       assert_equal(expected_sql, @output.string)
     end

--- a/spec/texticle/full_text_indexer_spec.rb
+++ b/spec/texticle/full_text_indexer_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'fileutils'
+require 'texticle/searchable'
 
 class FullTextIndexerTest < Test::Unit::TestCase
   context ".stream_output" do

--- a/spec/texticle/full_text_indexer_spec.rb
+++ b/spec/texticle/full_text_indexer_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'fileutils'
-require 'texticle/searchable'
 
 class FullTextIndexerTest < Test::Unit::TestCase
   context ".stream_output" do

--- a/spec/texticle/searchable_spec.rb
+++ b/spec/texticle/searchable_spec.rb
@@ -3,80 +3,101 @@ require 'texticle/searchable'
 
 class SearchableTest < Test::Unit::TestCase
   context "when extending an ActiveRecord::Base subclass" do
-    setup do
-      @qcont = WebComic.create :name => "Questionable Content", :author => "Jeph Jaques"
-      @jhony = WebComic.create :name => "Johnny Wander", :author => "Ananth & Yuko"
-      @ddeeg = WebComic.create :name => "Dominic Deegan", :author => "Mookie"
-      @penny = WebComic.create :name => "Penny Arcade", :author => "Tycho & Gabe"
-    end
-
-    teardown do
-      WebComic.delete_all
-      #Object.send(:remove_const, :WebComic) if defined?(WebComic)
-    end
-
     context "with no parameters" do
+      class WebComicWithSearchable < WebComic
+        extend Searchable
+      end
+
       setup do
-        WebComic.extend Searchable
+        @qcont = WebComicWithSearchable.create :name => "Questionable Content", :author => "Jeph Jaques"
+        @jhony = WebComicWithSearchable.create :name => "Johnny Wander", :author => "Ananth & Yuko"
+        @ddeeg = WebComicWithSearchable.create :name => "Dominic Deegan", :author => "Mookie"
+        @penny = WebComicWithSearchable.create :name => "Penny Arcade", :author => "Tycho & Gabe"
+      end
+
+      teardown do
+        WebComicWithSearchable.delete_all
       end
 
       should "search across all columns" do
-        assert_equal [@penny], WebComic.advanced_search("Penny")
-        assert_equal [@ddeeg], WebComic.advanced_search("Dominic")
+        assert_equal [@penny], WebComicWithSearchable.advanced_search("Penny")
+        assert_equal [@ddeeg], WebComicWithSearchable.advanced_search("Dominic")
       end
     end
 
     context "with one column as parameter" do
+      class WebComicWithSearchableName < WebComic
+        extend Searchable(:name)
+      end
+
       setup do
-        WebComic.extend Searchable(:name)
+        @qcont = WebComicWithSearchableName.create :name => "Questionable Content", :author => "Jeph Jaques"
+        @jhony = WebComicWithSearchableName.create :name => "Johnny Wander", :author => "Ananth & Yuko"
+        @ddeeg = WebComicWithSearchableName.create :name => "Dominic Deegan", :author => "Mookie"
+        @penny = WebComicWithSearchableName.create :name => "Penny Arcade", :author => "Tycho & Gabe"
+      end
+
+      teardown do
+        WebComicWithSearchableName.delete_all
       end
 
       should "only search across the given column" do
-        assert_equal [@penny], WebComic.advanced_search("Penny")
-        assert_empty WebComic.advanced_search("Tycho")
+        assert_equal [@penny], WebComicWithSearchableName.advanced_search("Penny")
+        assert_empty WebComicWithSearchableName.advanced_search("Tycho")
       end
 
       ["hello \\", "tebow!" , "food &"].each do |search_term|
         should "be fine with searching for crazy character #{search_term} with plain search" do
           # Uses plainto_tsquery
-          assert_equal [], WebComic.basic_search(search_term)
+          assert_equal [], WebComicWithSearchableName.basic_search(search_term)
         end
 
         should "be not fine with searching for crazy character #{search_term} with advanced search" do
           # Uses to_tsquery
           assert_raise(ActiveRecord::StatementInvalid) do
-            WebComic.advanced_search(search_term).all
+            WebComicWithSearchableName.advanced_search(search_term).all
           end
         end
       end
 
       should "fuzzy search stuff" do
-        assert_equal [@qcont], WebComic.fuzzy_search('Questio')
+        assert_equal [@qcont], WebComicWithSearchableName.fuzzy_search('Questio')
       end
 
       should "define :searchable_columns as private" do
-        assert_raise(NoMethodError) { WebComic.searchable_columns }
+        assert_raise(NoMethodError) { WebComicWithSearchableName.searchable_columns }
         begin
-          WebComic.searchable_columns
+          WebComicWithSearchableName.searchable_columns
         rescue NoMethodError => error
           assert_match error.message, /private method/
         end
       end
 
       should "define #indexable_columns which returns a write-proof Enumerable" do
-        assert_equal(Enumerator, WebComic.indexable_columns.class)
-        assert_raise(NoMethodError) { WebComic.indexable_columns[0] = 'foo' }
+        assert_equal(Enumerator, WebComicWithSearchableName.indexable_columns.class)
+        assert_raise(NoMethodError) { WebComicWithSearchableName.indexable_columns[0] = 'foo' }
       end
     end
 
     context "with two columns as parameters" do
+      class WebComicWithSearchableNameAndAuthor < WebComic
+        extend Searchable(:name, :author)
+      end
+
       setup do
-        WebComic.extend Searchable(:name, :author)
+        @qcont = WebComicWithSearchableNameAndAuthor.create :name => "Questionable Content", :author => "Jeph Jaques"
+        @jhony = WebComicWithSearchableNameAndAuthor.create :name => "Johnny Wander", :author => "Ananth & Yuko"
+        @ddeeg = WebComicWithSearchableNameAndAuthor.create :name => "Dominic Deegan", :author => "Mookie"
+        @penny = WebComicWithSearchableNameAndAuthor.create :name => "Penny Arcade", :author => "Tycho & Gabe"
+      end
+
+      teardown do
+        WebComicWithSearchableNameAndAuthor.delete_all
       end
 
       should "only search across the given column" do
-        assert_equal [@penny], WebComic.advanced_search("Penny")
-        assert_equal [@penny], WebComic.advanced_search("Tycho")
+        assert_equal [@penny], WebComicWithSearchableNameAndAuthor.advanced_search("Penny")
+        assert_equal [@penny], WebComicWithSearchableNameAndAuthor.advanced_search("Tycho")
       end
     end
   end

--- a/spec/texticle/searchable_spec.rb
+++ b/spec/texticle/searchable_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'fixtures/webcomic'
 require 'texticle/searchable'
 
 class SearchableTest < Test::Unit::TestCase

--- a/spec/texticle/searchable_spec.rb
+++ b/spec/texticle/searchable_spec.rb
@@ -4,10 +4,6 @@ require 'texticle/searchable'
 class SearchableTest < Test::Unit::TestCase
   context "when extending an ActiveRecord::Base subclass" do
     context "with no parameters" do
-      class WebComicWithSearchable < WebComic
-        extend Searchable
-      end
-
       setup do
         @qcont = WebComicWithSearchable.create :name => "Questionable Content", :author => "Jeph Jaques"
         @jhony = WebComicWithSearchable.create :name => "Johnny Wander", :author => "Ananth & Yuko"
@@ -26,10 +22,6 @@ class SearchableTest < Test::Unit::TestCase
     end
 
     context "with one column as parameter" do
-      class WebComicWithSearchableName < WebComic
-        extend Searchable(:name)
-      end
-
       setup do
         @qcont = WebComicWithSearchableName.create :name => "Questionable Content", :author => "Jeph Jaques"
         @jhony = WebComicWithSearchableName.create :name => "Johnny Wander", :author => "Ananth & Yuko"
@@ -80,10 +72,6 @@ class SearchableTest < Test::Unit::TestCase
     end
 
     context "with two columns as parameters" do
-      class WebComicWithSearchableNameAndAuthor < WebComic
-        extend Searchable(:name, :author)
-      end
-
       setup do
         @qcont = WebComicWithSearchableNameAndAuthor.create :name => "Questionable Content", :author => "Jeph Jaques"
         @jhony = WebComicWithSearchableNameAndAuthor.create :name => "Johnny Wander", :author => "Ananth & Yuko"

--- a/spec/texticle_spec.rb
+++ b/spec/texticle_spec.rb
@@ -1,8 +1,5 @@
 # coding: utf-8
 require 'spec_helper'
-require 'fixtures/webcomic'
-require 'fixtures/character'
-require 'fixtures/game'
 
 class TexticleTest < Test::Unit::TestCase
   context "after extending ActiveRecord::Base" do

--- a/spec/texticle_spec.rb
+++ b/spec/texticle_spec.rb
@@ -76,9 +76,6 @@ class TexticleTest < Test::Unit::TestCase
   end
 
   context "after extending an ActiveRecord::Base subclass" do
-    # before(:all)
-    class ::GameFail < Game; end
-
     setup do
       @zelda = Game.create :system => "NES",     :title => "Legend of Zelda",    :description => "A Link to the Past."
       @mario = Game.create :system => "NES",     :title => "Super Mario Bros.",  :description => "The original platformer."

--- a/spec/texticle_spec.rb
+++ b/spec/texticle_spec.rb
@@ -3,13 +3,21 @@ require 'spec_helper'
 
 class TexticleTest < Test::Unit::TestCase
   context "after extending ActiveRecord::Base" do
-    # before(:all)
-    ActiveRecord::Base.extend(Texticle)
-    class NotThere < ActiveRecord::Base; end
+
+    # set up modules so that Texticle won't be forever mixed into ActiveRecord
+    class ARStandIn < ActiveRecord::Base;
+      self.abstract_class = true
+      extend Texticle
+    end
+    class NotThere < ARStandIn; end
+    class TexticleWebComic < ARStandIn;
+      has_many :characters, :foreign_key => :web_comic_id
+      self.table_name = :web_comics
+    end
 
     should "not break #respond_to?" do
       assert_nothing_raised do
-        ActiveRecord::Base.respond_to? :abstract_class?
+        ARStandIn.respond_to? :abstract_class?
       end
     end
 
@@ -21,9 +29,9 @@ class TexticleTest < Test::Unit::TestCase
     end
 
     should "not break #method_missing" do
-      assert_raise(NoMethodError) { ActiveRecord::Base.random }
+      assert_raise(NoMethodError) { ARStandIn.random }
       begin
-        ActiveRecord::Base.random
+        ARStandIn.random
       rescue NoMethodError => error
         assert_match error.message, /undefined method `random'/
       end
@@ -41,9 +49,9 @@ class TexticleTest < Test::Unit::TestCase
 
     context "when finding models based on searching a related model" do
       setup do
-        @qc = WebComic.create :name => "Questionable Content", :author => "Jeph Jaques"
-        @jw = WebComic.create :name => "Johnny Wander", :author => "Ananth & Yuko"
-        @pa = WebComic.create :name => "Penny Arcade", :author => "Tycho & Gabe"
+        @qc = TexticleWebComic.create :name => "Questionable Content", :author => "Jeph Jaques"
+        @jw = TexticleWebComic.create :name => "Johnny Wander", :author => "Ananth & Yuko"
+        @pa = TexticleWebComic.create :name => "Penny Arcade", :author => "Tycho & Gabe"
 
         @gabe = @pa.characters.create :name => 'Gabe', :description => 'the simple one'
         @tycho = @pa.characters.create :name => 'Tycho', :description => 'the wordy one'
@@ -60,166 +68,175 @@ class TexticleTest < Test::Unit::TestCase
       end
 
       teardown do
-        WebComic.delete_all
+        TexticleWebComic.delete_all
         Character.delete_all
       end
 
       should "look in the related model with nested searching syntax" do
-        assert_equal [@jw], WebComic.joins(:characters).advanced_search(:characters => {:description => 'tall'})
-        assert_equal [@pa, @jw, @qc].sort, WebComic.joins(:characters).advanced_search(:characters => {:description => 'anger'}).sort
-        assert_equal [@pa, @qc].sort, WebComic.joins(:characters).advanced_search(:characters => {:description => 'crude'}).sort
+        assert_equal [@jw], TexticleWebComic.joins(:characters).advanced_search(:characters => {:description => 'tall'})
+        assert_equal [@pa, @jw, @qc].sort, TexticleWebComic.joins(:characters).advanced_search(:characters => {:description => 'anger'}).sort
+        assert_equal [@pa, @qc].sort, TexticleWebComic.joins(:characters).advanced_search(:characters => {:description => 'crude'}).sort
       end
     end
   end
 
   context "after extending an ActiveRecord::Base subclass" do
+    class GameExtendedWithTexticle < Game
+      extend Texticle
+    end
+
+    class GameFailExtendedWithTexticle < GameFail
+      extend Texticle
+    end
+
     setup do
-      @zelda = Game.create :system => "NES",     :title => "Legend of Zelda",    :description => "A Link to the Past."
-      @mario = Game.create :system => "NES",     :title => "Super Mario Bros.",  :description => "The original platformer."
-      @sonic = Game.create :system => "Genesis", :title => "Sonic the Hedgehog", :description => "Spiky."
-      @dkong = Game.create :system => "SNES",    :title => "Diddy's Kong Quest", :description => "Donkey Kong Country 2"
-      @megam = Game.create :system => nil,       :title => "Mega Man",           :description => "Beware Dr. Brain"
-      @sfnes = Game.create :system => "SNES",    :title => "Street Fighter 2",   :description => "Yoga Flame!"
-      @sfgen = Game.create :system => "Genesis", :title => "Street Fighter 2",   :description => "Yoga Flame!"
-      @takun = Game.create :system => "Saturn",  :title => "Magical Tarurūto-kun", :description => "カッコイイ！"
+      @zelda = GameExtendedWithTexticle.create :system => "NES",     :title => "Legend of Zelda",    :description => "A Link to the Past."
+      @mario = GameExtendedWithTexticle.create :system => "NES",     :title => "Super Mario Bros.",  :description => "The original platformer."
+      @sonic = GameExtendedWithTexticle.create :system => "Genesis", :title => "Sonic the Hedgehog", :description => "Spiky."
+      @dkong = GameExtendedWithTexticle.create :system => "SNES",    :title => "Diddy's Kong Quest", :description => "Donkey Kong Country 2"
+      @megam = GameExtendedWithTexticle.create :system => nil,       :title => "Mega Man",           :description => "Beware Dr. Brain"
+      @sfnes = GameExtendedWithTexticle.create :system => "SNES",    :title => "Street Fighter 2",   :description => "Yoga Flame!"
+      @sfgen = GameExtendedWithTexticle.create :system => "Genesis", :title => "Street Fighter 2",   :description => "Yoga Flame!"
+      @takun = GameExtendedWithTexticle.create :system => "Saturn",  :title => "Magical Tarurūto-kun", :description => "カッコイイ！"
     end
 
     teardown do
-      Game.delete_all
+      GameExtendedWithTexticle.delete_all
     end
 
     should "not break respond_to? when connection is unavailable" do
-      GameFail.establish_connection({:adapter => :postgresql, :database =>'unavailable', :username=>'bad', :pool=>5, :timeout=>5000}) rescue nil
+      GameFailExtendedWithTexticle.establish_connection({:adapter => :postgresql, :database =>'unavailable', :username=>'bad', :pool=>5, :timeout=>5000}) rescue nil
 
       assert_nothing_raised do
-        GameFail.respond_to?(:advanced_search)
+        GameFailExtendedWithTexticle.respond_to?(:advanced_search)
       end
-
     end
 
     should "define a #search method" do
-      assert Game.respond_to?(:search)
+      assert GameExtendedWithTexticle.respond_to?(:search)
     end
 
     context "when searching with a String argument" do
       should "search across all :string columns if no indexes have been specified" do
-        assert_equal [@mario], Game.advanced_search("Mario")
-        assert_equal Set.new([@mario, @zelda]), Game.advanced_search("NES").to_set
+        assert_equal [@mario], GameExtendedWithTexticle.advanced_search("Mario")
+        assert_equal Set.new([@mario, @zelda]), GameExtendedWithTexticle.advanced_search("NES").to_set
       end
 
       should "work if the query contains an apostrophe" do
-        assert_equal [@dkong], Game.advanced_search("Diddy's")
+        assert_equal [@dkong], GameExtendedWithTexticle.advanced_search("Diddy's")
       end
 
       should "work if the query contains whitespace" do
-        assert_equal [@megam], Game.advanced_search("Mega Man")
+        assert_equal [@megam], GameExtendedWithTexticle.advanced_search("Mega Man")
       end
 
       should "work if the query contains an accent" do
-        assert_equal [@takun], Game.advanced_search("Tarurūto-kun")
+        assert_equal [@takun], GameExtendedWithTexticle.advanced_search("Tarurūto-kun")
       end
 
       should "search across records with NULL values" do
-        assert_equal [@megam], Game.advanced_search("Mega")
+        assert_equal [@megam], GameExtendedWithTexticle.advanced_search("Mega")
       end
 
       should "scope consecutively" do
-        assert_equal [@sfgen], Game.advanced_search("Genesis").advanced_search("Street Fighter")
+        assert_equal [@sfgen], GameExtendedWithTexticle.advanced_search("Genesis").advanced_search("Street Fighter")
       end
     end
 
     context "when searching with a Hash argument" do
       should "search across the given columns" do
-        assert_empty Game.advanced_search(:title => "NES")
-        assert_empty Game.advanced_search(:system => "Mario")
-        assert_empty Game.advanced_search(:system => "NES", :title => "Sonic")
+        assert_empty GameExtendedWithTexticle.advanced_search(:title => "NES")
+        assert_empty GameExtendedWithTexticle.advanced_search(:system => "Mario")
+        assert_empty GameExtendedWithTexticle.advanced_search(:system => "NES", :title => "Sonic")
 
-        assert_equal [@mario], Game.advanced_search(:title => "Mario")
+        assert_equal [@mario], GameExtendedWithTexticle.advanced_search(:title => "Mario")
 
-        assert_equal 2, Game.advanced_search(:system => "NES").count
+        assert_equal 2, GameExtendedWithTexticle.advanced_search(:system => "NES").count
 
-        assert_equal [@zelda], Game.advanced_search(:system => "NES", :title => "Zelda")
-        assert_equal [@megam], Game.advanced_search(:title => "Mega")
+        assert_equal [@zelda], GameExtendedWithTexticle.advanced_search(:system => "NES", :title => "Zelda")
+        assert_equal [@megam], GameExtendedWithTexticle.advanced_search(:title => "Mega")
       end
 
       should "scope consecutively" do
-        assert_equal [@sfgen], Game.advanced_search(:system => "Genesis").advanced_search(:title => "Street Fighter")
+        assert_equal [@sfgen], GameExtendedWithTexticle.advanced_search(:system => "Genesis").advanced_search(:title => "Street Fighter")
       end
 
       should "cast non-:string columns as text" do
-        assert_equal [@mario], Game.advanced_search(:id => @mario.id)
+        assert_equal [@mario], GameExtendedWithTexticle.advanced_search(:id => @mario.id)
       end
     end
 
     context "when using dynamic search methods" do
       should "generate methods for each :string column" do
-        assert_equal [@mario], Game.advanced_search_by_title("Mario")
-        assert_equal [@takun], Game.advanced_search_by_system("Saturn")
+        assert_equal [@mario], GameExtendedWithTexticle.advanced_search_by_title("Mario")
+        assert_equal [@takun], GameExtendedWithTexticle.advanced_search_by_system("Saturn")
       end
 
       should "generate methods for each :text column" do
-        assert_equal [@mario], Game.advanced_search_by_description("platform")
+        assert_equal [@mario], GameExtendedWithTexticle.advanced_search_by_description("platform")
       end
 
       should "generate methods for any combination of :string and :text columns" do
-        assert_equal [@mario], Game.advanced_search_by_title_and_system("Mario", "NES")
-        assert_equal [@sonic], Game.advanced_search_by_system_and_title("Genesis", "Sonic")
-        assert_equal [@mario], Game.advanced_search_by_title_and_title("Mario", "Mario")
-        assert_equal [@megam], Game.advanced_search_by_title_and_description("Man", "Brain")
+        assert_equal [@mario], GameExtendedWithTexticle.advanced_search_by_title_and_system("Mario", "NES")
+        assert_equal [@sonic], GameExtendedWithTexticle.advanced_search_by_system_and_title("Genesis", "Sonic")
+        assert_equal [@mario], GameExtendedWithTexticle.advanced_search_by_title_and_title("Mario", "Mario")
+        assert_equal [@megam], GameExtendedWithTexticle.advanced_search_by_title_and_description("Man", "Brain")
       end
 
       should "generate methods for inclusive searches" do
-        assert_equal Set.new([@megam, @takun]), Game.advanced_search_by_system_or_title("Saturn", "Mega Man").to_set
+        assert_equal Set.new([@megam, @takun]), GameExtendedWithTexticle.advanced_search_by_system_or_title("Saturn", "Mega Man").to_set
       end
 
       should "scope consecutively" do
-        assert_equal [@sfgen], Game.advanced_search_by_system("Genesis").advanced_search_by_title("Street Fighter")
+        assert_equal [@sfgen], GameExtendedWithTexticle.advanced_search_by_system("Genesis").advanced_search_by_title("Street Fighter")
       end
 
       should "generate methods for non-:string columns" do
-        assert_equal [@mario], Game.advanced_search_by_id(@mario.id)
+        assert_equal [@mario], GameExtendedWithTexticle.advanced_search_by_id(@mario.id)
       end
 
       should "work with #respond_to?" do
-        assert Game.respond_to?(:advanced_search_by_system)
-        assert Game.respond_to?(:advanced_search_by_title)
-        assert Game.respond_to?(:advanced_search_by_system_and_title)
-        assert Game.respond_to?(:advanced_search_by_system_or_title)
-        assert Game.respond_to?(:advanced_search_by_title_and_title_and_title)
-        assert Game.respond_to?(:advanced_search_by_id)
+        assert GameExtendedWithTexticle.respond_to?(:advanced_search_by_system)
+        assert GameExtendedWithTexticle.respond_to?(:advanced_search_by_title)
+        assert GameExtendedWithTexticle.respond_to?(:advanced_search_by_system_and_title)
+        assert GameExtendedWithTexticle.respond_to?(:advanced_search_by_system_or_title)
+        assert GameExtendedWithTexticle.respond_to?(:advanced_search_by_title_and_title_and_title)
+        assert GameExtendedWithTexticle.respond_to?(:advanced_search_by_id)
 
-        assert !Game.respond_to?(:advanced_search_by_title_and_title_or_title)
+        assert !GameExtendedWithTexticle.respond_to?(:advanced_search_by_title_and_title_or_title)
       end
 
       should "allow for 2 arguments to #respond_to?" do
-        assert Game.respond_to?(:normalize, true)
+        assert GameExtendedWithTexticle.respond_to?(:normalize, true)
       end
     end
 
     context "when searching after selecting columns to return" do
       should "not fetch extra columns" do
         assert_raise(ActiveModel::MissingAttributeError) do
-          Game.select(:title).advanced_search("Mario").first.system
+          GameExtendedWithTexticle.select(:title).advanced_search("Mario").first.system
         end
       end
     end
-  end
 
-  context "when setting a custom search language" do
-    def Game.searchable_language
-      'spanish'
-    end
+    context "when setting a custom search language" do
+      class GameExtendedWithTexticleAndCustomLanguage < GameExtendedWithTexticle
+        def searchable_language
+          'spanish'
+        end
+      end
 
-    setup do
-      Game.create :system => "PS3", :title => "Harry Potter & the Deathly Hallows"
-    end
+      setup do
+        GameExtendedWithTexticleAndCustomLanguage.create :system => "PS3", :title => "Harry Potter & the Deathly Hallows"
+      end
 
-    teardown do
-      Game.delete_all
-    end
+      teardown do
+        GameExtendedWithTexticleAndCustomLanguage.delete_all
+      end
 
-    should "still find results" do
-      assert_not_empty Game.advanced_search_by_title("harry")
+      should "still find results" do
+        assert_not_empty GameExtendedWithTexticleAndCustomLanguage.advanced_search_by_title("harry")
+      end
     end
   end
 end

--- a/spec/texticle_spec.rb
+++ b/spec/texticle_spec.rb
@@ -3,18 +3,6 @@ require 'spec_helper'
 
 class TexticleTest < Test::Unit::TestCase
   context "after extending ActiveRecord::Base" do
-
-    # set up modules so that Texticle won't be forever mixed into ActiveRecord
-    class ARStandIn < ActiveRecord::Base;
-      self.abstract_class = true
-      extend Texticle
-    end
-    class NotThere < ARStandIn; end
-    class TexticleWebComic < ARStandIn;
-      has_many :characters, :foreign_key => :web_comic_id
-      self.table_name = :web_comics
-    end
-
     should "not break #respond_to?" do
       assert_nothing_raised do
         ARStandIn.respond_to? :abstract_class?
@@ -81,14 +69,6 @@ class TexticleTest < Test::Unit::TestCase
   end
 
   context "after extending an ActiveRecord::Base subclass" do
-    class GameExtendedWithTexticle < Game
-      extend Texticle
-    end
-
-    class GameFailExtendedWithTexticle < GameFail
-      extend Texticle
-    end
-
     setup do
       @zelda = GameExtendedWithTexticle.create :system => "NES",     :title => "Legend of Zelda",    :description => "A Link to the Past."
       @mario = GameExtendedWithTexticle.create :system => "NES",     :title => "Super Mario Bros.",  :description => "The original platformer."
@@ -220,12 +200,6 @@ class TexticleTest < Test::Unit::TestCase
     end
 
     context "when setting a custom search language" do
-      class GameExtendedWithTexticleAndCustomLanguage < GameExtendedWithTexticle
-        def searchable_language
-          'spanish'
-        end
-      end
-
       setup do
         GameExtendedWithTexticleAndCustomLanguage.create :system => "PS3", :title => "Harry Potter & the Deathly Hallows"
       end


### PR DESCRIPTION
(I ported this issue from [the original at the old repo](https://github.com/tenderlove/texticle/issues/64).)

@ecin said, in a pull request comment:

> The [test] code probably could use cleanup; our texticle_spec.rb file is certainly looking too long.

So I thought I'd start a discussion about it. I'm willing to do the work, but don't want to go off in a random direction no one would find useful. If it were just me, I'd actually use RSpec and rewrite everything with that. I understand not everyone's a big fan of that, so I'm not going to push it too hard, but I thought I'd at least mention it. I like the colored output and the fact that it'll traverse directory structures for you.

Also, we have these model classes that we're reusing in various places and including modules or extending them, etc. And once something's included in a class as long as the class is still in memory (the whole test suite), that module will always be included, so all tests that follow will not really be in isolation... they'll be with that module included. That seems a bit dangerous.

Then there's the question of how tests should be organized. There's not a lot of code in this gem, but when I first started writing pull requests, it wasn't clear to me where I should be adding tests for the functionality I was adding, so maybe we should break things up some more and rearrange it. I'm just not sure how.

Anyone, of course, is welcome to pipe up. In particular, though, it'd be nice to hear from the folks with commit access to the repo. :smile:
