### PR TITLE
Update README.rdoc to mention using sql for schema_format.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,6 +50,9 @@ In the above example, the table email_logs has two text columns that we search a
 You will need to add an index for every text/string column you query against, or else Postgresql will revert to a
 full table scan instead of using the indexes.
 
+If you create these indexes, you should also switch to sql for your schema_format in `config/application.rb`:
+
+  config.active_record.schema_format = :sql
 
 == REQUIREMENTS:
 


### PR DESCRIPTION
Using `execute` in migrations does not make it to db/schema.rb, so you should use db/structure.sql instead.
