### PR TITLE
Only require version in gemspec

### DIFF
--- a/lib/texticle.rb
+++ b/lib/texticle.rb
@@ -1,8 +1,8 @@
 require 'active_record'
 
-module Texticle
-  VERSION = '2.0.3'
+require 'texticle/version'
 
+module Texticle
   def self.version
     VERSION
   end

--- a/lib/texticle.rb
+++ b/lib/texticle.rb
@@ -3,10 +3,6 @@ require 'active_record'
 require 'texticle/version'
 
 module Texticle
-  def self.version
-    VERSION
-  end
-
   def self.searchable_language
     'english'
   end

--- a/lib/texticle/version.rb
+++ b/lib/texticle/version.rb
@@ -1,0 +1,3 @@
+module Texticle
+  VERSION = '2.0.3'
+end

--- a/lib/texticle/version.rb
+++ b/lib/texticle/version.rb
@@ -1,3 +1,7 @@
 module Texticle
   VERSION = '2.0.3'
+
+  def self.version
+    VERSION
+  end
 end

--- a/texticle.gemspec
+++ b/texticle.gemspec
@@ -1,10 +1,10 @@
 # -*- encoding: utf-8 -*-
 
-require File.expand_path('../lib/texticle', __FILE__)
+require File.expand_path('../lib/texticle/version', __FILE__)
 
 Gem::Specification.new do |s|
   s.name    = 'texticle'
-  s.version = Texticle.version
+  s.version = Texticle::VERSION
 
   s.summary     = 'Texticle exposes full text search capabilities from PostgreSQL'
   s.description = 'Texticle exposes full text search capabilities from PostgreSQL, extending


### PR DESCRIPTION
Using texticle master in a Gemfile using git fails due to failure to require
active_record, which is required by the top level texticle.rb, loaded by the
gemspec, which only actually requires the version.
