### PR TITLE
Adding the use of '|' and '&' in queries to README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -38,7 +38,7 @@ Your models now have access to the search method:
   Game.search_by_title_and_system('Final Fantasy', 'PS2')
   Game.search_by_title_or_system('Final Fantasy, 'PS3')
 
-You can use '|' annd '&' for logical conditions.
+You can use '|' and '&' for logical conditions.
 
   Game.search_by_title_or_system('Final Fantasy', 'PS3|Xbox')
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -38,6 +38,10 @@ Your models now have access to the search method:
   Game.search_by_title_and_system('Final Fantasy', 'PS2')
   Game.search_by_title_or_system('Final Fantasy, 'PS3')
 
+You can use '|' annd '&' for logical conditions.
+
+  Game.search_by_title_or_system('Final Fantasy', 'PS3|Xbox')
+
 === Setting Language
 
 To set proper searchig dictionary just override class method on your model:


### PR DESCRIPTION
I was pretty confused because I couldn't figure out how to use logical operators in queries.
This is probably useful for newbies like me.
