### PR TITLE
Update gemspec to allow Rails 4 support

### DIFF
--- a/texticle.gemspec
+++ b/texticle.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-doc'
 
-  s.add_dependency('activerecord', '~> 3.0')
+  s.add_dependency('activerecord', [">= 3.1", "< 4.1"])
 end

--- a/texticle.gemspec
+++ b/texticle.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-doc'
 
-  s.add_dependency('activerecord', [">= 3.1", "< 4.1"])
+  s.add_dependency('activerecord', [">= 3.0", "< 4.1"])
 end


### PR DESCRIPTION
Quickly tested `#advanced_search` and `#fuzzy_search` and everything worked fine under the latest Rails 4 from [rails/master](http://github.com/rails/rails)

Used the same solution as [haml-rails](https://github.com/indirect/haml-rails/blob/master/haml-rails.gemspec#L21) did recently.
